### PR TITLE
Check for # before prefixing links; resolves #31.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "develop": "gatsby develop",
     "start": "gatsby develop",
-    "build": "rm -rf .cache/gatsby-source-git/ && gatsby build",
+    "build": "gatsby clean && gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "lint": "eslint --color --ext .js --ignore-path .gitignore ."

--- a/plugins/gatsby-remark-prefix-relative-links/index.js
+++ b/plugins/gatsby-remark-prefix-relative-links/index.js
@@ -8,7 +8,11 @@ module.exports = ({ markdownAST, markdownNode }, options = {}) => {
   
   const appendPrefix = () => {
     visit(markdownAST, 'link', (node) => {
-      if (node && !node.url.startsWith('http')) {
+      if (!node || !node.url) return;
+      const isAbsolute = node.url.startsWith('http');
+      const isFragment = node.url.startsWith('#');
+      const requiresPrefix = !isAbsolute && !isFragment;
+      if (requiresPrefix) {
         node.url = `${prefix}/${node.url}`
           .replace('index.md', '')
           .replace('.md', '/')


### PR DESCRIPTION
This worked locally, but I had a weird runtime error that was only resolved by clearing the build cache first, so I want to see what happens in the preview build before merging.