### PR TITLE
Reference correct GPL v2 license.

### DIFF
--- a/src/content/index.md
+++ b/src/content/index.md
@@ -34,6 +34,6 @@ other ways, or talk with developers and other users on the
 [farmOS Community Forum]: https://farmOS.discourse.group
 [making a donation]: /donate
 [contributing]: /community/contribute
-[GNU General Public License]: http://www.gnu.org/copyleft/gpl.html
+[GNU General Public License]: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 [free]: https://en.wikipedia.org/wiki/Free_software
 [open source]: http://en.wikipedia.org/wiki/Open_source


### PR DESCRIPTION
The current farmOS.org home page links to a generic gnu.org link that redirects to GPL v3. Someone reached out because this is confusing given our farmOS server source code is actually GPL v2.

http://www.gnu.org/copyleft/gpl.html

Actually just looking closer... the wording "Both are licensed under the [GNU General Public License](http://www.gnu.org/copyleft/gpl.html)" is a bit generic. Originally I think this referred to both farmOS server & Drupal. I suspect that later on Field Kit was added, which complicates things because it is licensed under GPL v3. Maybe we could reword some of this?

> Note that these pages reflect farmOS version 2 and its corresponding client applications and libraries.

Should we consider adding a note that Field Kit is not ready for v2? We could pull this into a separate paragraph after the note about GNU GPL?