### PR TITLE
301 Redirect /guide/assets/sensors/ to https://v1.farmos.org/guide/assets/sensors/

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -22,6 +22,7 @@ https://docs.farmos.org/* https://farmos.org/:splat 301!
 /development/release/ https://v1.farmos.org/development/release/ 301
 /development/update-safety/ https://v1.farmos.org/development/update-safety/ 301
 /faq/ https://v1.farmos.org/faq/ 301
+/guide/assets/sensors/ https://v1.farmos.org/guide/assets/sensors/ 301
 /hosting/apikeys/ https://v1.farmos.org/hosting/apikeys/ 301
 /hosting/googlemaps/ https://v1.farmos.org/hosting/apikeys/ 301
 /hosting/localization/ https://v1.farmos.org/hosting/localization/ 301


### PR DESCRIPTION
Google Search Console is reporting 404 Not Found on /guide/assets/sensors/, which is an old path from the v1 docs.

This explicitly adds a 301 redirect for that path to the corresponding path on v1.farmos.org.