### PR TITLE
Embed Mastodon feed in homepage

### DIFF
--- a/src/content/index.md
+++ b/src/content/index.md
@@ -23,6 +23,9 @@ You can contribute to the project by [making a donation] or [contributing] in
 other ways, or talk with developers and other users on the
 [farmOS Community Forum].
 
+<a rel="me" href="https://fosstodon.org/@farmOS">Follow @farmOS on fosstodon.org</a>
+<iframe allowfullscreen sandbox="allow-top-navigation allow-scripts" style="width:100% !important; height:600px; border:1px #ccc solid !important;" src="https://www.mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Ffosstodon.org%2Fusers%2FfarmOS&theme=light&size=100&header=true&replies=false&boosts=false"></iframe>
+
 [v1.farmOS.org]: https://v1.farmos.org
 [Drupal]: https://drupal.org
 [modular]: http://en.wikipedia.org/wiki/Modular_programming


### PR DESCRIPTION
See original ideas that led to this here: https://irc.farmos.org/bot/log/farmOS/2022-11-11#T84623

Opening this as a draft for consideration/discussion. Iframe embed code generated from http://www.mastofeed.com/ - probably needs some CSS polish to make it more responsive.