### PR TITLE
update chat link

### DIFF
--- a/src/content/config.yml
+++ b/src/content/config.yml
@@ -4,7 +4,7 @@ nav:
 - Community:
     - Code of Conduct: community/conduct.md
     - Monthly Call: community/monthly-call.md
-    - Chat: https://riot.im/app/#/room/#farmOS:matrix.org
+    - Chat: https://app.element.io/#/room/#farmOS:matrix.org
     - Forum: https://farmOS.discourse.group/
     - Maintainers: community/maintainers.md
     - Supporters: community/supporters.md


### PR DESCRIPTION
Riot.im was renamed to element.io in 2020. The old link is correctly redirected to the new one, but it is probably a good idea to just directly use the new link.