### PR TITLE
change monthly call url of Riot.im to Element.io

### DIFF
--- a/src/content/community/monthly-call.md
+++ b/src/content/community/monthly-call.md
@@ -8,7 +8,7 @@ agenda and archive of call notes can be found [on the forum](https://farmos.disc
 
 Refer to the schedule below, and use the "Join Call" link to join the call.
 
-**NOTE:** In case you have problems joining a call, check the Riot.im [chat room].
+**NOTE:** In case you have problems joining a call, check the Element.io [chat room].
 Last minute updates or changes will be communicated there!
 
 ## [Join Call]
@@ -50,4 +50,4 @@ December 13th @ 2pm EST / 7pm UTC
 
 [Jitsi]: https://meet.jit.si/
 [Join Call]: /community/monthly-call/join
-[chat room]: https://riot.im/app/#/room/#farmOS:matrix.org
+[chat room]: https://app.element.io/#/room/#farmOS:matrix.org


### PR DESCRIPTION
Hi farmOS, 

Noticed that the monthly call page pointed to a wrong/obsolete url for Riot.im.
They announced this a while back:
[welcome-to-element](https://element.io/blog/welcome-to-element/)
[Riot blog - the world is changing](https://blog.riot.im/the-world-is-changing/)
