### PR TITLE
Contrib modules/projects listing page

### DIFF
--- a/src/content/config.yml
+++ b/src/content/config.yml
@@ -11,3 +11,4 @@ nav:
     - Press: community/press.md
     - Trademark: community/trademark.md
     - Donate: donate.md
+    - Projects: community/projects

--- a/src/pages/community/projects/index.js
+++ b/src/pages/community/projects/index.js
@@ -70,8 +70,8 @@ const ProjectsPage = () => {
           <>
             <Typography variant='h2'>Other projects</Typography>
             <ul>
-              {otherProjects.map(module => {
-                return (<li><Link to={module['drupal.org'] || module.src}>{module.name}</Link> - {module.desc}</li>)
+              {otherProjects.map(project => {
+                return (<li><Link to={project['drupal.org'] || project.src}>{project.name}</Link> - {project.desc}</li>)
               })}
             </ul>
           </>

--- a/src/pages/community/projects/index.js
+++ b/src/pages/community/projects/index.js
@@ -1,0 +1,84 @@
+import * as React from "react"
+import { useEffect, useState } from "react";
+import { Helmet } from "react-helmet";
+import { Link } from 'gatsby-material-ui-components';
+import { makeStyles } from '@material-ui/core/styles';
+import { Box, Typography } from '@material-ui/core';
+import theme from '../../../theme';
+
+const useStyles = makeStyles({
+  main: {
+    '& h1': {
+      color: theme.palette.text.secondary,
+      fontWeight: 300,
+      fontSize: '2rem',
+      lineHeight: 1.3,
+      letterSpacing: '-.01em',
+      margin: '0 0 1.25rem',
+    },
+    '& h2': {
+      margin: '1.6rem 0 0.64rem',
+      fontSize: '1.5625rem',
+      fontWeight: 300,
+      lineHeight: 1.4,
+      letterSpacing: '-.01em',
+    }
+  },
+});
+
+const ProjectsPage = () => {
+  const classes = useStyles();
+  const [contribModules, setContribModules] = useState([]);
+  const [customModules, setCustomModules] = useState([]);
+  const [otherProjects, setOtherProjects] = useState([]);
+  useEffect(() => {
+    async function fetchData() {
+      const response = await fetch(`https://raw.githubusercontent.com/wotnak/farmos-community-projects/main/projects.json`)
+      const data = await response.json();
+      setContribModules(data.filter(value => value.type === 'contrib-module'))
+      setCustomModules(data.filter(value => value.type === 'custom-module'))
+      setOtherProjects(data.filter(value => value.type === 'project'))
+    }
+    fetchData();
+  }, []);
+  return (
+    <>
+      <Helmet title="Community Projects"></Helmet>
+      <Box component='main' className={classes.main}>
+        <Typography variant='h1'>Community Projects</Typography>
+        {contribModules.length > 0 &&
+          <>
+            <Typography variant='h2'>Contrib modules</Typography>
+            <ul>
+              {contribModules.map(module => {
+                return (<li><Link to={module['drupal.org'] || module.src}>{module.name}</Link> - {module.desc}</li>)
+              })}
+            </ul>
+          </>
+        }
+        {customModules.length > 0 &&
+          <>
+            <Typography variant='h2'>Custom modules</Typography>
+            <ul>
+              {customModules.map(module => {
+                return (<li><Link to={module['drupal.org'] || module.src}>{module.name}</Link> - {module.desc}</li>)
+              })}
+            </ul>
+          </>
+        }
+        {otherProjects.length > 0 &&
+          <>
+            <Typography variant='h2'>Other projects</Typography>
+            <ul>
+              {otherProjects.map(module => {
+                return (<li><Link to={module['drupal.org'] || module.src}>{module.name}</Link> - {module.desc}</li>)
+              })}
+            </ul>
+          </>
+        }
+      </Box>
+    </>
+  );
+};
+
+export default ProjectsPage;


### PR DESCRIPTION
This pr adds a page that list contrib modules/projects listed in https://github.com/wotnak/farmos-community-projects.
The goal of this is to improve discoverability of farmOS v2 addons/integrations.

Related discussion on the forum: https://farmos.discourse.group/t/contrib-modules-tools-list/1531

Before merging this:
- projects.json file, which this page reads data from, should have defined schema https://github.com/wotnak/farmos-community-projects/issues/2
- decision on what is considered a contrib vs custom module should be made
    - main question is if only modules published to drupal.org should be considered contrib or other modules that have general enough approach and are published for example only on github should also be included
- projects list repo probably should be moved to the farmOS github org
- page name and placement in the site menu should be reviewd
    - currently I named it analogous to the repo with the projects list, but maybe naming it `Addons` and placing it under `Hosting` menu section would make it more easily discoverable