### PR TITLE
fix anchor links getting covered by the site header

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -21,6 +21,7 @@ const theme = createTheme({
         html: {
           height: '100%',
           overflowX: 'hidden',
+          scrollPaddingTop: '64px',
         },
         body: {
           height: '100%',


### PR DESCRIPTION
Fixes https://github.com/farmOS/farmOS.org/issues/69 by applying [`scroll-padding-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-top) to the `<html>` element to offset anchor link scroll by the site header height.