### PR TITLE
Improved fix for anchor links getting covered by the site header 

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -21,7 +21,6 @@ const theme = createTheme({
         html: {
           height: '100%',
           overflowX: 'hidden',
-          scrollPaddingTop: '64px',
         },
         body: {
           height: '100%',
@@ -29,6 +28,9 @@ const theme = createTheme({
         '#___gatsby, #gatsby-focus-wrapper': {
           all: 'inherit',
         },
+        '[id], [name]': {
+          scrollMarginTop: '64px'
+        }
       },
     },
   },


### PR DESCRIPTION
`scroll-padding-top` solution for #69 from #70 works well when using anchor links on the page but doesn't fix the issue when linking to the anchor from an external site, for example clicking https://farmos.org/guide/#dashboard will redirect to the site with section title still covered by the site header.

This pr replaces `scroll-padding-top` on html with `scroll-margin-top` on anchor elements, which correctly applies scroll offset also when linking to a specific section from an external site.