### PR TITLE
Update homepage text

### DIFF
--- a/src/content/index.md
+++ b/src/content/index.md
@@ -9,8 +9,7 @@ data collection and management.**
 
 The farmOS server is built on top of [Drupal], which makes it [modular],
 [extensible], and [secure]. The [farmOS Field Kit] app provides offline data
-entry in a native Android/iOS app, and as a progressive web app (PWA) at
-[farmOS.app].
+entry via a progressive web app (PWA) at [farmOS.app].
 
 Both are licensed under the [GNU General Public License], which means they are
 [free] and [open source]. All code is available in the [farmOS GitHub]

--- a/src/content/index.md
+++ b/src/content/index.md
@@ -7,10 +7,6 @@ keeping. It is developed by a community of farmers, developers, researchers, and
 organizations with the aim of providing a standard platform for agricultural
 data collection and management.**
 
-Note that these pages reflect farmOS version 2 and its corresponding client
-applications and libraries. For archived documentation of farmOS version 1,
-please visit [v1.farmos.org].
-
 The farmOS server is built on top of [Drupal], which makes it [modular],
 [extensible], and [secure]. The [farmOS Field Kit] app provides offline data
 entry in a native Android/iOS app, and as a progressive web app (PWA) at
@@ -32,7 +28,6 @@ Subscribe to the [farmOS newsletter]
 
 This site is powered by [Netlify](https://www.netlify.com)
 
-[v1.farmOS.org]: https://v1.farmos.org
 [Drupal]: https://drupal.org
 [modular]: http://en.wikipedia.org/wiki/Modular_programming
 [extensible]: https://www.drupal.org/download


### PR DESCRIPTION
Couple of small updates to the homepage:

- **Remove note about version 2 and link to v1.farmos.org from homepage.** This paragraph was originally added during the transition from v1 to v2. Now we are transitioning to v3. The old v1 docs are less and less relevant. Maybe we can consider adding a link to them somewhere else on the site, but as a first step I think this paragraph can be removed from the homepage.
- **Remove mention of Field Kit's "native Android/iOS app" from homepage.** We dropped support for the native apps a long time ago, and forgot to remove this from the homepage. It is causing confusion (eg: https://farmos.discourse.group/t/android-app-location/1804).