### PR TITLE
Add "Get farmOS, "Develop farmOS", and "Follow farmOS" headers and links to homepage

### DIFF
--- a/src/content/index.md
+++ b/src/content/index.md
@@ -19,6 +19,15 @@ You can contribute to the project by [making a donation] or [contributing] in
 other ways, or talk with developers and other users on the
 [farmOS Community Forum].
 
+## Get farmOS
+
+See the [farmOS Hosting Guide] for an overview of hosting options.
+
+If you would like to host farmOS yourself, read the [farmOS Installation Guide]
+and the [farmOS Update Guide] to learn how.
+
+## Follow farmOS
+
 Subscribe to the [farmOS newsletter]
 <iframe scrolling="no" style="width: 100% !important; height: 220px; border:1px #ccc solid !important" src="https://buttondown.email/farmOS?as_embed=true"></iframe>
 
@@ -42,3 +51,6 @@ This site is powered by [Netlify](https://www.netlify.com)
 [open source]: http://en.wikipedia.org/wiki/Open_source
 [farmOS GitHub]: https://github.com/farmOS
 [farmOS newsletter]: https://buttondown.email/farmOS
+[farmOS Hosting Guide]: /hosting
+[farmOS Installation Guide]: /hosting/install
+[farmOS Update Guide]: /hosting/update

--- a/src/content/index.md
+++ b/src/content/index.md
@@ -26,6 +26,15 @@ See the [farmOS Hosting Guide] for an overview of hosting options.
 If you would like to host farmOS yourself, read the [farmOS Installation Guide]
 and the [farmOS Update Guide] to learn how.
 
+## Develop farmOS
+
+To join the farmOS community development efforts, read the
+[Contributing to farmOS] overview, and join the community forum, chat, or calls.
+
+- Forum: [farmOS.discourse.group]
+- Chat: [#farmOS on Matrix.org] or [#farmOS on IRC]
+- Calls: [Monthly community call] / [Weekly development call]
+
 ## Follow farmOS
 
 Subscribe to the [farmOS newsletter]
@@ -54,3 +63,10 @@ This site is powered by [Netlify](https://www.netlify.com)
 [farmOS Hosting Guide]: /hosting
 [farmOS Installation Guide]: /hosting/install
 [farmOS Update Guide]: /hosting/update
+[Contributing to farmOS]: /community/contributing
+[farmOS.discourse.group]: https://farmOS.discourse.group
+[#farmOS on Matrix.org]: https://app.element.io/#/room/#farmOS:matrix.org
+[#farmOS on IRC]: https://webchat.oftc.net/?channels=#farmOS
+[Monthly community call]: /community/monthly-call
+[Weekly development call]: https://farmOS.discourse.group/t/farmos-community-calls/972
+

--- a/src/content/index.md
+++ b/src/content/index.md
@@ -35,6 +35,10 @@ To join the farmOS community development efforts, read the
 - Chat: [#farmOS on Matrix.org] or [#farmOS on IRC]
 - Calls: [Monthly community call] / [Weekly development call]
 
+farmOS consists of a number of Git repositories in the
+[farmOS GitHub Organization], as well as numerous community contributed modules
+and integrations.
+
 ## Follow farmOS
 
 Subscribe to the [farmOS newsletter]
@@ -59,7 +63,6 @@ This site is powered by [Netlify](https://www.netlify.com)
 [free]: https://en.wikipedia.org/wiki/Free_software
 [open source]: http://en.wikipedia.org/wiki/Open_source
 [farmOS GitHub]: https://github.com/farmOS
-[farmOS newsletter]: https://buttondown.email/farmOS
 [farmOS Hosting Guide]: /hosting
 [farmOS Installation Guide]: /hosting/install
 [farmOS Update Guide]: /hosting/update
@@ -69,4 +72,5 @@ This site is powered by [Netlify](https://www.netlify.com)
 [#farmOS on IRC]: https://webchat.oftc.net/?channels=#farmOS
 [Monthly community call]: /community/monthly-call
 [Weekly development call]: https://farmOS.discourse.group/t/farmos-community-calls/972
-
+[farmOS GitHub Organization]: https://github.com/farmOS
+[farmOS newsletter]: https://buttondown.email/farmOS


### PR DESCRIPTION
This add a bunch of links to the homepage, based on feedback we've heard from the community. It also adds 3 `<h2>` headers to organize everything:

- Get farmOS
- Develop farmOS
- Follow farmOS