### PR TITLE
Add OpenCollective refund disclaimer to /donate

### DIFF
--- a/src/content/community/supporters.md
+++ b/src/content/community/supporters.md
@@ -99,7 +99,7 @@ Thank you to all our OpenCollective backers! [[Become a backer](https://opencoll
 
 ## OpenCollective Sponsors
 
-Support this project by becoming an OpenCollective sponsor. Your logo will show up here with a link to your website. [[Become a sponsor](https://opencollective.com/farmOS#sponsor)]
+Support this project by becoming an OpenCollective sponsor. [[Become a sponsor](https://opencollective.com/farmOS#sponsor)]
 
 <a href="https://opencollective.com/farmOS/sponsor/0/website" target="_blank"><img src="https://opencollective.com/farmOS/sponsor/0/avatar.svg"></a>
 <a href="https://opencollective.com/farmOS/sponsor/1/website" target="_blank"><img src="https://opencollective.com/farmOS/sponsor/1/avatar.svg"></a>

--- a/src/content/donate.md
+++ b/src/content/donate.md
@@ -99,6 +99,12 @@ Sincerely,
 
 <script src="https://opencollective.com/farmOS/banner.js"></script>
 
+### Refund Disclaimer
+
+Contributions made through OpenCollective are considered a donation. No goods
+or services are expected in return. Any requests for refunds for those purposes
+will be rejected.
+
 [Open Source Collective]: https://opencollective.com/opensourcecollective
 [https://opencollective.com/farmOS]: https://opencollective.com/farmOS
 [free and open source software]: https://en.wikipedia.org/wiki/Free_and_open-source_software


### PR DESCRIPTION
OpenCollective sent out this email to collective maintainers yesterday:

https://opencollective.com/opensource/updates/important-osc-update-refund-policy-and-donation-disclaimer

This PR adds the new language to /donate, and also removes the text "Your logo will show up here with a link to your website." from /community/supporters