### PR TITLE
Update farmOS docs for 4.x

### DIFF
--- a/site-data.js
+++ b/site-data.js
@@ -36,7 +36,7 @@ module.exports = {
       baseURI: '/',
       config: 'mkdocs.yml',
       remote: process.env.FARMOS_REPO || 'https://github.com/farmOS/farmOS.git',
-      branch: process.env.FARMOS_REPO_BRANCH || '3.x',
+      branch: process.env.FARMOS_REPO_BRANCH || '4.x',
       directory: 'docs/',
       template: DOCS_TEMPLATE,
     },


### PR DESCRIPTION
This updates farmOS.org to pull docs from the 4.x branch of https://github.com/farmOS/farmOS/